### PR TITLE
fix: cosmetics

### DIFF
--- a/assets/css/blog/post.css
+++ b/assets/css/blog/post.css
@@ -2,6 +2,10 @@
     margin-bottom: 100px;
 }
 
+.post.tag-podcast {
+  margin-bottom: 0;
+}
+
 .post-media {
     margin-bottom: 20px;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "broadcast",
     "description": "A Ghost theme",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "private": true,
     "engines": {
         "ghost": ">=5.0.0"

--- a/partials/components/navbar.hbs
+++ b/partials/components/navbar.hbs
@@ -21,7 +21,6 @@
 
         <nav class="gh-head-menu">
             {{navigation}}
-            <a class="gh-head-link" href="/blog">Blog</a>
             {{#unless @site.members_enabled}}
                 {{#match navigationLayout "Stacked"}}
                     <button class="gh-search gh-icon-btn" aria-label="Search this site" data-ghost-search>{{> "icons/search"}}</button>


### PR DESCRIPTION
### Link To Issue:
N/A
### Description of Issue:
Spacing was too wide between episode listings and routing.yaml upload made the blog link irrelevant 
### Solution:
Add a more specific styling for the list and remove the manually added blog link in the nav
### Notes:
